### PR TITLE
Add simple web game

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Jeu de la Complicité</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <h1>Jeu de la Complicité</h1>
+
+    <div id="scoreboard">
+        <div class="team" id="team1">
+            <span class="name">Équipe 1</span>
+            <span class="score" id="score1">0</span>
+        </div>
+        <div class="team" id="team2">
+            <span class="name">Équipe 2</span>
+            <span class="score" id="score2">0</span>
+        </div>
+    </div>
+
+    <div id="active-team">Équipe active : <span id="activeName">Équipe 1</span></div>
+
+    <div id="word-display">Appuyez sur "Nouvelle manche"</div>
+
+    <div id="timer">60</div>
+
+    <div id="controls">
+        <button id="start">Nouvelle manche</button>
+        <button id="correct" disabled>Mot trouvé</button>
+    </div>
+
+    <script src="script.js"></script>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,56 @@
+const words = [
+    'Chat', 'Chocolat', 'Avion', 'Pyramide', 'Pirate',
+    'Bateau', 'Arc-en-ciel', 'Licorne', 'Robot', 'Montagne'
+];
+
+let activeTeam = 1;
+let timer;
+let timeLeft = 60;
+
+function updateActiveTeam() {
+    const name = activeTeam === 1 ? 'Équipe 1' : 'Équipe 2';
+    document.getElementById('activeName').textContent = name;
+}
+
+function startRound() {
+    // pick random word
+    const word = words[Math.floor(Math.random() * words.length)];
+    document.getElementById('word-display').textContent = word;
+
+    // reset timer
+    timeLeft = 60;
+    document.getElementById('timer').textContent = timeLeft;
+
+    document.getElementById('correct').disabled = false;
+
+    timer = setInterval(() => {
+        timeLeft--;
+        document.getElementById('timer').textContent = timeLeft;
+        if (timeLeft <= 0) {
+            endRound(false);
+        }
+    }, 1000);
+}
+
+function endRound(correct) {
+    clearInterval(timer);
+    document.getElementById('correct').disabled = true;
+    if (correct) {
+        const scoreId = 'score' + activeTeam;
+        const current = parseInt(document.getElementById(scoreId).textContent, 10);
+        document.getElementById(scoreId).textContent = current + 1;
+    }
+
+    // switch active team
+    activeTeam = activeTeam === 1 ? 2 : 1;
+    updateActiveTeam();
+    document.getElementById('word-display').textContent = 'Appuyez sur "Nouvelle manche"';
+    document.getElementById('timer').textContent = '60';
+}
+
+// event listeners
+
+document.getElementById('start').addEventListener('click', startRound);
+document.getElementById('correct').addEventListener('click', () => endRound(true));
+
+updateActiveTeam();

--- a/style.css
+++ b/style.css
@@ -1,0 +1,43 @@
+body {
+    font-family: Arial, sans-serif;
+    margin: 20px;
+    text-align: center;
+}
+
+#scoreboard {
+    display: flex;
+    justify-content: space-around;
+    margin-bottom: 20px;
+}
+
+.team {
+    border: 1px solid #333;
+    padding: 10px;
+    width: 100px;
+}
+
+.score {
+    font-size: 2em;
+    display: block;
+}
+
+#active-team {
+    margin-bottom: 20px;
+    font-weight: bold;
+}
+
+#word-display {
+    font-size: 2em;
+    margin: 20px 0;
+}
+
+#timer {
+    font-size: 1.5em;
+    margin: 10px 0;
+}
+
+button {
+    padding: 10px 20px;
+    font-size: 1em;
+    margin: 5px;
+}


### PR DESCRIPTION
## Summary
- implement a simple HTML/CSS/JS game to guess words
- keep track of two team scores
- round timer automatically switches active team

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683f7daa79d88322a74065bb4fea7723