### PR TITLE
Allow custom round duration and words

### DIFF
--- a/index.html
+++ b/index.html
@@ -26,6 +26,14 @@
 
     <div id="timer">60</div>
 
+    <div id="settings">
+        <label for="round-duration">Durée d'une manche (s) :</label>
+        <input type="number" id="round-duration" value="60" min="1">
+        <br>
+        <label for="custom-words">Mots personnalisés (séparés par des virgules) :</label>
+        <input type="text" id="custom-words" placeholder="mot1,mot2">
+    </div>
+
     <div id="controls">
         <button id="start">Nouvelle manche</button>
         <button id="correct" disabled>Mot trouvé</button>

--- a/script.js
+++ b/script.js
@@ -1,4 +1,4 @@
-const words = [
+const defaultWords = [
     'Chat', 'Chocolat', 'Avion', 'Pyramide', 'Pirate',
     'Bateau', 'Arc-en-ciel', 'Licorne', 'Robot', 'Montagne'
 ];
@@ -7,18 +7,40 @@ let activeTeam = 1;
 let timer;
 let timeLeft = 60;
 
+function loadSettings() {
+    const savedDuration = localStorage.getItem('duration');
+    if (savedDuration !== null) {
+        document.getElementById('round-duration').value = savedDuration;
+        document.getElementById('timer').textContent = savedDuration;
+        timeLeft = parseInt(savedDuration, 10);
+    } else {
+        document.getElementById('timer').textContent = timeLeft;
+    }
+    const savedWords = localStorage.getItem('customWords');
+    if (savedWords !== null) {
+        document.getElementById('custom-words').value = savedWords;
+    }
+}
+
 function updateActiveTeam() {
     const name = activeTeam === 1 ? 'Équipe 1' : 'Équipe 2';
     document.getElementById('activeName').textContent = name;
 }
 
 function startRound() {
-    // pick random word
-    const word = words[Math.floor(Math.random() * words.length)];
+    const duration = parseInt(document.getElementById('round-duration').value, 10) || 60;
+    const customInput = document.getElementById('custom-words').value;
+
+    localStorage.setItem('duration', duration);
+    localStorage.setItem('customWords', customInput);
+
+    const customWords = customInput.split(',').map(w => w.trim()).filter(w => w);
+    const availableWords = defaultWords.concat(customWords);
+
+    const word = availableWords[Math.floor(Math.random() * availableWords.length)];
     document.getElementById('word-display').textContent = word;
 
-    // reset timer
-    timeLeft = 60;
+    timeLeft = duration;
     document.getElementById('timer').textContent = timeLeft;
 
     document.getElementById('correct').disabled = false;
@@ -45,7 +67,7 @@ function endRound(correct) {
     activeTeam = activeTeam === 1 ? 2 : 1;
     updateActiveTeam();
     document.getElementById('word-display').textContent = 'Appuyez sur "Nouvelle manche"';
-    document.getElementById('timer').textContent = '60';
+    document.getElementById('timer').textContent = document.getElementById('round-duration').value;
 }
 
 // event listeners
@@ -54,3 +76,4 @@ document.getElementById('start').addEventListener('click', startRound);
 document.getElementById('correct').addEventListener('click', () => endRound(true));
 
 updateActiveTeam();
+loadSettings();


### PR DESCRIPTION
## Summary
- add UI inputs for round duration and custom words
- persist duration and words via `localStorage`
- update round logic to use saved settings

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_683f7fb4a6748322870d45b7e1ee077e