### PR TITLE
Disable start button during countdown

### DIFF
--- a/script.js
+++ b/script.js
@@ -22,6 +22,7 @@ function startRound() {
     document.getElementById('timer').textContent = timeLeft;
 
     document.getElementById('correct').disabled = false;
+    document.getElementById('start').disabled = true;
 
     timer = setInterval(() => {
         timeLeft--;
@@ -35,6 +36,7 @@ function startRound() {
 function endRound(correct) {
     clearInterval(timer);
     document.getElementById('correct').disabled = true;
+    document.getElementById('start').disabled = false;
     if (correct) {
         const scoreId = 'score' + activeTeam;
         const current = parseInt(document.getElementById(scoreId).textContent, 10);


### PR DESCRIPTION
## Summary
- prevent multiple rounds from starting by disabling the "Nouvelle manche" button as soon as a round begins
- re-enable the button when `endRound()` completes

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683f7fb8717c8322ac10ed2210f69690