### PR TITLE
Add team-specific scoring controls

### DIFF
--- a/index.html
+++ b/index.html
@@ -37,7 +37,8 @@
 
     <div id="controls">
         <button id="start">Nouvelle manche</button>
-        <button id="correct" disabled>Mot trouvé</button>
+        <button id="team1-found" disabled>Équipe 1 a trouvé</button>
+        <button id="team2-found" disabled>Équipe 2 a trouvé</button>
     </div>
 
     </div> <!-- end container -->

--- a/script.js
+++ b/script.js
@@ -43,24 +43,26 @@ function startRound() {
     timeLeft = duration;
     document.getElementById('timer').textContent = timeLeft;
 
-    document.getElementById('correct').disabled = false;
+    document.getElementById('team1-found').disabled = false;
+    document.getElementById('team2-found').disabled = false;
     document.getElementById('start').disabled = true;
 
     timer = setInterval(() => {
         timeLeft--;
         document.getElementById('timer').textContent = timeLeft;
         if (timeLeft <= 0) {
-            endRound(false);
+            endRound(null);
         }
     }, 1000);
 }
 
-function endRound(correct) {
+function endRound(winnerTeam) {
     clearInterval(timer);
-    document.getElementById('correct').disabled = true;
+    document.getElementById('team1-found').disabled = true;
+    document.getElementById('team2-found').disabled = true;
     document.getElementById('start').disabled = false;
-    if (correct) {
-        const scoreId = 'score' + activeTeam;
+    if (winnerTeam === 1 || winnerTeam === 2) {
+        const scoreId = 'score' + winnerTeam;
         const current = parseInt(document.getElementById(scoreId).textContent, 10);
         document.getElementById(scoreId).textContent = current + 1;
     }
@@ -75,7 +77,8 @@ function endRound(correct) {
 // event listeners
 
 document.getElementById('start').addEventListener('click', startRound);
-document.getElementById('correct').addEventListener('click', () => endRound(true));
+document.getElementById('team1-found').addEventListener('click', () => endRound(1));
+document.getElementById('team2-found').addEventListener('click', () => endRound(2));
 
 updateActiveTeam();
 loadSettings();


### PR DESCRIPTION
## Summary
- add buttons for each team to claim a found word
- enable both buttons at the start of a round
- track the winning team in `endRound`
- wire up new event handlers

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_683f84d04ab0832285d0c268a9f67f9d