### PR TITLE
Record time spent on rounds

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # Jeux de la Complicité
 
 ## But du projet
-Ce dépôt contient une petite application web permettant de jouer au *Jeu de la Complicité*. Deux équipes s’affrontent en essayant de deviner un mot avant la fin d’un compte à rebours de 60 secondes. Chaque mot trouvé rapporte un point à l’équipe active.
+Ce dépôt contient une petite application web permettant de jouer au *Jeu de la Complicité*. Deux équipes s’affrontent en essayant de deviner un mot le plus rapidement possible. Chaque mot trouvé rapporte un point à l’équipe active et le chronomètre indique le temps mis.
 
 ## Règles du jeu
 1. Au début d’une manche, cliquez sur **Nouvelle manche** pour afficher un mot aléatoire et lancer le minuteur.
 2. L’équipe active tente de faire deviner le mot à ses coéquipiers sans le prononcer directement.
 3. Quand le mot est trouvé, cliquez sur **Mot trouvé** pour ajouter un point à cette équipe et passer la main à l’équipe suivante.
-4. Si le temps s’écoule avant que le mot ne soit deviné, la manche se termine automatiquement et c’est à l’autre équipe de jouer.
+4. La manche se termine quand le mot est deviné et le temps réalisé reste affiché.
 
 ## Ouvrir l’application
 Aucune installation n’est nécessaire. Pour jouer :

--- a/script.js
+++ b/script.js
@@ -5,16 +5,15 @@ const defaultWords = [
 
 let activeTeam = 1;
 let timer;
-let timeLeft = 60;
+let elapsedSeconds = 0;
 
 function loadSettings() {
     const savedDuration = localStorage.getItem('duration');
     if (savedDuration !== null) {
         document.getElementById('round-duration').value = savedDuration;
         document.getElementById('timer').textContent = savedDuration;
-        timeLeft = parseInt(savedDuration, 10);
     } else {
-        document.getElementById('timer').textContent = timeLeft;
+        document.getElementById('timer').textContent = document.getElementById('round-duration').value;
     }
     const savedWords = localStorage.getItem('customWords');
     if (savedWords !== null) {
@@ -40,19 +39,16 @@ function startRound() {
     const word = availableWords[Math.floor(Math.random() * availableWords.length)];
     document.getElementById('word-display').textContent = word;
 
-    timeLeft = duration;
-    document.getElementById('timer').textContent = timeLeft;
+    elapsedSeconds = 0;
+    document.getElementById('timer').textContent = elapsedSeconds;
 
     document.getElementById('team1-found').disabled = false;
     document.getElementById('team2-found').disabled = false;
     document.getElementById('start').disabled = true;
 
     timer = setInterval(() => {
-        timeLeft--;
-        document.getElementById('timer').textContent = timeLeft;
-        if (timeLeft <= 0) {
-            endRound(null);
-        }
+        elapsedSeconds++;
+        document.getElementById('timer').textContent = elapsedSeconds;
     }, 1000);
 }
 
@@ -71,7 +67,7 @@ function endRound(winnerTeam) {
     activeTeam = activeTeam === 1 ? 2 : 1;
     updateActiveTeam();
     document.getElementById('word-display').textContent = 'Appuyez sur "Nouvelle manche"';
-    document.getElementById('timer').textContent = document.getElementById('round-duration').value;
+    document.getElementById('timer').textContent = elapsedSeconds;
 }
 
 // event listeners


### PR DESCRIPTION
## Summary
- measure the time elapsed instead of a countdown
- show the final time when a team ends a round
- update documentation to describe the new timer behavior

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683f85bac8e48322b135c9aa743facad