### PR TITLE
Remove duration setting

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,12 +25,9 @@
 
     <div id="word-display">Appuyez sur "Nouvelle manche"</div>
 
-    <div id="timer">60</div>
+    <div id="timer">0</div>
 
     <div id="settings">
-        <label for="round-duration">Durée d'une manche (s) :</label>
-        <input type="number" id="round-duration" value="60" min="1">
-        <br>
         <label for="custom-words">Mots personnalisés (séparés par des virgules) :</label>
         <input type="text" id="custom-words" placeholder="mot1,mot2">
     </div>

--- a/script.js
+++ b/script.js
@@ -8,17 +8,11 @@ let timer;
 let elapsedSeconds = 0;
 
 function loadSettings() {
-    const savedDuration = localStorage.getItem('duration');
-    if (savedDuration !== null) {
-        document.getElementById('round-duration').value = savedDuration;
-        document.getElementById('timer').textContent = savedDuration;
-    } else {
-        document.getElementById('timer').textContent = document.getElementById('round-duration').value;
-    }
     const savedWords = localStorage.getItem('customWords');
     if (savedWords !== null) {
         document.getElementById('custom-words').value = savedWords;
     }
+    document.getElementById('timer').textContent = 0;
 }
 
 function updateActiveTeam() {
@@ -32,10 +26,8 @@ function updateActiveTeam() {
 }
 
 function startRound() {
-    const duration = parseInt(document.getElementById('round-duration').value, 10) || 60;
     const customInput = document.getElementById('custom-words').value;
 
-    localStorage.setItem('duration', duration);
     localStorage.setItem('customWords', customInput);
 
     const customWords = customInput.split(',').map(w => w.trim()).filter(w => w);


### PR DESCRIPTION
## Summary
- remove `round-duration` input from the page
- stop persisting a custom duration and always start rounds from 0

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_683f89bf47848322b52adb18d190082e