### PR TITLE
Add score persistence and reset feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,3 +25,4 @@ Le jeu s’affiche alors directement dans le navigateur et peut être utilisé h
 - **Nouvelle manche** : tire un mot aléatoire, remet le chronomètre à zéro et active les boutons de résolution.
 - **Équipe 1 a trouvé** / **Équipe 2 a trouvé** : arrêtent le chronomètre et ajoutent un point à l’équipe correspondante.
 - L’équipe actuellement active est indiquée sous le tableau de scores et la case de cette équipe est encadrée d’une bordure colorée.
+- **Réinitialiser les scores** : remet les scores à zéro. Les scores et l’équipe active sont sauvegardés entre les sessions.

--- a/index.html
+++ b/index.html
@@ -37,6 +37,7 @@
         <button id="start">Nouvelle manche</button>
         <button id="team1-found" disabled>Équipe 1 a trouvé</button>
         <button id="team2-found" disabled>Équipe 2 a trouvé</button>
+        <button id="reset-scores">Réinitialiser les scores</button>
     </div>
 
     </div> <!-- end container -->

--- a/script.js
+++ b/script.js
@@ -12,7 +12,16 @@ function loadSettings() {
     if (savedWords !== null) {
         document.getElementById('custom-words').value = savedWords;
     }
+    const s1 = parseInt(localStorage.getItem('score1'), 10);
+    const s2 = parseInt(localStorage.getItem('score2'), 10);
+    if (!isNaN(s1)) document.getElementById('score1').textContent = s1;
+    if (!isNaN(s2)) document.getElementById('score2').textContent = s2;
+    const savedTeam = parseInt(localStorage.getItem('activeTeam'), 10);
+    if (savedTeam === 1 || savedTeam === 2) {
+        activeTeam = savedTeam;
+    }
     document.getElementById('timer').textContent = 0;
+    updateActiveTeam();
 }
 
 function updateActiveTeam() {
@@ -23,6 +32,20 @@ function updateActiveTeam() {
     const team2 = document.getElementById('team2');
     team1.classList.toggle('active-team', activeTeam === 1);
     team2.classList.toggle('active-team', activeTeam === 2);
+}
+
+function saveGameState() {
+    localStorage.setItem('score1', document.getElementById('score1').textContent);
+    localStorage.setItem('score2', document.getElementById('score2').textContent);
+    localStorage.setItem('activeTeam', activeTeam);
+}
+
+function resetScores() {
+    document.getElementById('score1').textContent = 0;
+    document.getElementById('score2').textContent = 0;
+    activeTeam = 1;
+    updateActiveTeam();
+    saveGameState();
 }
 
 function startRound() {
@@ -68,6 +91,7 @@ function endRound(winnerTeam) {
     // switch active team
     activeTeam = activeTeam === 1 ? 2 : 1;
     updateActiveTeam();
+    saveGameState();
     const wordDisplay = document.getElementById('word-display');
     wordDisplay.textContent = 'Appuyez sur "Nouvelle manche"';
     wordDisplay.classList.remove('flash');
@@ -79,6 +103,7 @@ function endRound(winnerTeam) {
 document.getElementById('start').addEventListener('click', startRound);
 document.getElementById('team1-found').addEventListener('click', () => endRound(1));
 document.getElementById('team2-found').addEventListener('click', () => endRound(2));
+document.getElementById('reset-scores').addEventListener('click', resetScores);
 
 updateActiveTeam();
 loadSettings();

--- a/style.css
+++ b/style.css
@@ -90,6 +90,12 @@ h1 {
     margin-bottom: 15px;
 }
 
+#controls {
+    display: flex;
+    justify-content: center;
+    flex-wrap: wrap;
+}
+
 #timer {
     font-size: 2em;
     margin: 10px 0;


### PR DESCRIPTION
## Summary
- add reset button to UI
- persist scores and active team in localStorage
- allow resetting scores and team
- describe new control in README
- style controls container for wrap

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684070ad748c83229a43d5a2009d20bc