### PR TITLE
Ajout equipes et joueurs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,14 @@
 # Jeux de la Complicité
 
 ## But du projet
-Ce dépôt contient une petite application web permettant de jouer au *Jeu de la Complicité*. Deux équipes s’affrontent en essayant de deviner un mot le plus rapidement possible. Un chronomètre affiche le temps écoulé pour chaque manche et des boutons permettent d’ajouter un point à l’équipe ayant trouvé le mot, qu’elle soit ou non l’équipe active. Cette dernière change automatiquement à la fin de la manche et reste indiquée visuellement sur le tableau de score.
+Ce dépôt contient une petite application web permettant de jouer au *Jeu de la Complicité*. Plusieurs équipes peuvent être créées ainsi que des joueurs qui leur sont associés. Un chronomètre affiche le temps écoulé pour chaque manche et un point est attribué au joueur ayant trouvé le mot, ce qui incrémente automatiquement le score de son équipe. L’équipe active change automatiquement à la fin de la manche et reste indiquée visuellement sur le tableau de score.
 
 ## Règles du jeu
-1. Cliquez sur **Nouvelle manche** pour afficher un mot aléatoire et démarrer le chronomètre à 0.
-2. L’équipe active tente de faire deviner le mot à ses coéquipiers sans le prononcer.
-3. Lorsque le mot est trouvé, appuyez sur **Équipe 1 a trouvé** ou **Équipe 2 a trouvé**. Le chronomètre s’arrête et le point est attribué à l’équipe correspondante.
-4. L’équipe active change alors pour la manche suivante, même si l’autre équipe a marqué. Le temps réalisé reste affiché jusqu’à la prochaine manche.
+1. Sur l’écran de configuration, ajoutez les équipes puis les joueurs qui les composent, puis lancez la partie.
+2. Cliquez sur **Nouvelle manche** pour afficher un mot aléatoire et démarrer le chronomètre à 0.
+3. L’équipe active tente de faire deviner le mot à ses coéquipiers sans le prononcer.
+4. Quand le mot est trouvé, sélectionnez le joueur gagnant dans la liste puis cliquez sur **Mot trouvé**. Le joueur et son équipe gagnent un point et le chronomètre s’arrête.
+5. L’équipe active change alors pour la manche suivante. Le temps réalisé reste affiché jusqu’à la prochaine manche.
 
 ## Ouvrir l’application
 Aucune installation n’est nécessaire. Pour jouer :
@@ -22,7 +23,9 @@ Le jeu s’affiche alors directement dans le navigateur et peut être utilisé h
 - **script.js** : logique du jeu : tirage des mots aléatoires, gestion du minuteur, des scores et de l’équipe active.
 
 ## Commandes et interface
-- **Nouvelle manche** : tire un mot aléatoire, remet le chronomètre à zéro et active les boutons de résolution.
-- **Équipe 1 a trouvé** / **Équipe 2 a trouvé** : arrêtent le chronomètre et ajoutent un point à l’équipe correspondante.
+- **Ajouter une équipe** / **Ajouter un joueur** : permettent de préparer la partie sur l’écran de configuration.
+- **Commencer la partie** : passe à l’écran de jeu avec le tableau des scores.
+- **Nouvelle manche** : tire un mot aléatoire, remet le chronomètre à zéro et active le bouton de validation.
+- **Mot trouvé** : après avoir sélectionné le joueur gagnant, arrête le chronomètre et ajoute un point au joueur et à son équipe.
 - L’équipe actuellement active est indiquée sous le tableau de scores et la case de cette équipe est encadrée d’une bordure colorée.
-- **Réinitialiser les scores** : remet les scores à zéro. Les scores et l’équipe active sont sauvegardés entre les sessions.
+- **Réinitialiser les scores** : remet les scores de tous les joueurs et équipes à zéro.

--- a/index.html
+++ b/index.html
@@ -8,39 +8,31 @@
     <link rel="stylesheet" href="style.css">
 </head>
 <body>
-    <div class="container">
-    <h1>Jeu de la Complicité</h1>
+    <div id="config-container" class="container">
+        <h1>Configuration de la partie</h1>
+        <div id="teams-config"></div>
+        <button id="add-team">Ajouter une équipe</button>
+        <button id="start-game" disabled>Commencer la partie</button>
+    </div>
 
-    <div id="scoreboard">
-        <div class="team" id="team1">
-            <span class="name">Équipe 1</span>
-            <span class="score" id="score1">0</span>
+    <div id="game-container" class="container">
+        <h1>Jeu de la Complicité</h1>
+
+        <div id="scoreboard"></div>
+
+        <div id="active-team">Équipe active : <span id="activeName"></span></div>
+
+        <div id="word-display">Appuyez sur "Nouvelle manche"</div>
+
+        <div id="timer">0</div>
+
+        <div id="controls">
+            <button id="start">Nouvelle manche</button>
+            <select id="player-select"></select>
+            <button id="word-found" disabled>Mot trouvé</button>
+            <button id="reset-scores">Réinitialiser les scores</button>
         </div>
-        <div class="team" id="team2">
-            <span class="name">Équipe 2</span>
-            <span class="score" id="score2">0</span>
-        </div>
     </div>
-
-    <div id="active-team">Équipe active : <span id="activeName">Équipe 1</span></div>
-
-    <div id="word-display">Appuyez sur "Nouvelle manche"</div>
-
-    <div id="timer">0</div>
-
-    <div id="settings">
-        <label for="custom-words">Mots personnalisés (séparés par des virgules) :</label>
-        <input type="text" id="custom-words" placeholder="mot1,mot2">
-    </div>
-
-    <div id="controls">
-        <button id="start">Nouvelle manche</button>
-        <button id="team1-found" disabled>Équipe 1 a trouvé</button>
-        <button id="team2-found" disabled>Équipe 2 a trouvé</button>
-        <button id="reset-scores">Réinitialiser les scores</button>
-    </div>
-
-    </div> <!-- end container -->
     <script src="script.js"></script>
 </body>
 </html>

--- a/style.css
+++ b/style.css
@@ -28,6 +28,20 @@ body {
     max-width: 600px;
     width: 100%;
 }
+.config-team {
+    background: rgba(255, 255, 255, 0.6);
+    padding: 10px;
+    border-radius: 12px;
+    margin-bottom: 10px;
+}
+.config-team h3 {
+    margin: 0 0 5px;
+}
+.config-team ul {
+    list-style: none;
+    padding: 0;
+    margin: 0 0 5px;
+}
 
 h1 {
     margin-top: 0;
@@ -52,6 +66,13 @@ h1 {
     border-radius: 10px;
     box-shadow: 0 3px 8px rgba(0, 0, 0, 0.15);
     transition: transform 0.3s ease, box-shadow 0.3s ease;
+}
+.team .players {
+    margin-top: 10px;
+    font-size: 0.9em;
+}
+.team .players div {
+    margin: 2px 0;
 }
 .team .name {
     font-weight: 600;
@@ -86,9 +107,6 @@ h1 {
     font-weight: bold;
 }
 
-#settings {
-    margin-bottom: 15px;
-}
 
 #controls {
     display: flex;
@@ -130,7 +148,8 @@ button:hover:not(:disabled) {
 }
 
 input[type="number"],
-input[type="text"] {
+input[type="text"],
+select {
     padding: 8px 12px;
     border: 1px solid #ccc;
     border-radius: 6px;


### PR DESCRIPTION
## Summary
- remove custom words feature
- add configuration screen for teams and players
- allow multiple teams and players with per-player points
- update scoreboard and controls accordingly
- update README documentation

## Testing
- `node -v`


------
https://chatgpt.com/codex/tasks/task_e_6840bad344508322a410a28a1243aab8