### PR TITLE
Add dropdown for team count

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,7 +12,15 @@
         <h1>Configuration de la partie</h1>
         <div id="setup">
             <label for="team-count">Nombre d'équipes :</label>
-            <input type="number" id="team-count" min="2" value="2">
+            <select id="team-count">
+                <option value="2" selected>2</option>
+                <option value="3">3</option>
+                <option value="4">4</option>
+                <option value="5">5</option>
+                <option value="6">6</option>
+                <option value="7">7</option>
+                <option value="8">8</option>
+            </select>
             <button id="generate-teams">Créer les équipes</button>
         </div>
         <div id="teams-config"></div>

--- a/script.js
+++ b/script.js
@@ -191,7 +191,7 @@ function resetScores() {
 
 
 document.getElementById('generate-teams').addEventListener('click', () => {
-    const count = parseInt(document.getElementById('team-count').value, 10);
+    const count = parseInt(document.querySelector('#team-count').value, 10);
     if (isNaN(count) || count < 1) return;
     teams = Array.from({ length: count }, (_, i) => ({ name: `Équipe ${i + 1}`, score: 0, players: [] }));
     renderConfig();


### PR DESCRIPTION
## Summary
- replace numeric input with `<select>` for the number of teams
- grab the selected value from the dropdown when generating teams

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_6840c41dbecc8322a0812e681c66ca21