### PR TITLE
Fix timer bug when starting a new game

### DIFF
--- a/script.js
+++ b/script.js
@@ -233,6 +233,7 @@ document.getElementById('word-found').addEventListener('click', endRound);
 document.getElementById('reset-scores').addEventListener('click', resetScores);
 
 document.getElementById('menu-btn').addEventListener('click', () => {
+    clearInterval(timer);
     if (teams.length) {
         history.push({ date: new Date().toISOString(), teams: JSON.parse(JSON.stringify(teams)) });
     }


### PR DESCRIPTION
## Summary
- stop the interval timer when returning to the menu

## Testing
- `npm test` *(fails: could not find `package.json`)*

------
https://chatgpt.com/codex/tasks/task_e_6840c7a25808832287cc22fd86b4f767