### PR TITLE
Add reset and word reveal

### DIFF
--- a/index.html
+++ b/index.html
@@ -34,7 +34,10 @@
 
         <div id="active-team">Équipe active : <span id="activeName"></span></div>
 
-        <div id="word-display">Appuyez sur "Nouvelle manche"</div>
+        <div id="word-container">
+            <div id="word-display">Appuyez sur "Nouvelle manche"</div>
+            <button id="toggle-word" style="display:none" title="Afficher le mot">👁️</button>
+        </div>
 
         <div id="timer">0</div>
 

--- a/script.js
+++ b/script.js
@@ -9,6 +9,7 @@ let history = [];
 let activeTeamIndex = 0;
 let timer;
 let elapsedSeconds = 0;
+let currentWord = '';
 
 function loadState() {
     const data = localStorage.getItem('teams');
@@ -127,12 +128,14 @@ function updateActiveTeam() {
 }
 
 function startRound() {
-    const word = defaultWords[Math.floor(Math.random() * defaultWords.length)];
+    currentWord = defaultWords[Math.floor(Math.random() * defaultWords.length)];
     const wordDisplay = document.getElementById('word-display');
-    wordDisplay.textContent = word;
+    wordDisplay.textContent = currentWord;
+    wordDisplay.classList.add('hidden');
     wordDisplay.classList.remove('flash');
     void wordDisplay.offsetWidth;
     wordDisplay.classList.add('flash');
+    document.getElementById('toggle-word').style.display = 'block';
 
     elapsedSeconds = 0;
     document.getElementById('timer').textContent = elapsedSeconds;
@@ -170,7 +173,23 @@ function endRound() {
     const wordDisplay = document.getElementById('word-display');
     wordDisplay.textContent = 'Appuyez sur "Nouvelle manche"';
     wordDisplay.classList.remove('flash');
+    wordDisplay.classList.remove('hidden');
+    document.getElementById('toggle-word').style.display = 'none';
     document.getElementById('timer').textContent = elapsedSeconds;
+}
+
+function resetGameUI() {
+    clearInterval(timer);
+    elapsedSeconds = 0;
+    document.getElementById('timer').textContent = elapsedSeconds;
+    currentWord = '';
+    const wordDisplay = document.getElementById('word-display');
+    wordDisplay.textContent = 'Appuyez sur "Nouvelle manche"';
+    wordDisplay.classList.remove('flash');
+    wordDisplay.classList.remove('hidden');
+    document.getElementById('toggle-word').style.display = 'none';
+    document.getElementById('word-found').disabled = true;
+    document.getElementById('start').disabled = false;
 }
 
 function resetScores() {
@@ -214,6 +233,7 @@ document.getElementById('start-game').addEventListener('click', () => {
     });
     document.getElementById('config-container').style.display = 'none';
     document.getElementById('game-container').style.display = 'block';
+    resetGameUI();
     teams.forEach(team => {
         team.players.forEach(p => {
             if (players[p.name]) {
@@ -228,12 +248,15 @@ document.getElementById('start-game').addEventListener('click', () => {
 
 document.getElementById('start').addEventListener('click', startRound);
 
+document.getElementById('toggle-word').addEventListener('click', () => {
+    document.getElementById('word-display').classList.toggle('hidden');
+});
+
 document.getElementById('word-found').addEventListener('click', endRound);
 
 document.getElementById('reset-scores').addEventListener('click', resetScores);
 
 document.getElementById('menu-btn').addEventListener('click', () => {
-    clearInterval(timer);
     if (teams.length) {
         history.push({ date: new Date().toISOString(), teams: JSON.parse(JSON.stringify(teams)) });
     }
@@ -241,11 +264,14 @@ document.getElementById('menu-btn').addEventListener('click', () => {
     activeTeamIndex = 0;
     saveState();
     renderConfig();
+    resetGameUI();
     document.getElementById('game-container').style.display = 'none';
     document.getElementById('config-container').style.display = 'block';
 });
 
 loadState();
 renderConfig();
+
+resetGameUI();
 
 document.getElementById('game-container').style.display = 'none';

--- a/style.css
+++ b/style.css
@@ -107,12 +107,30 @@ h1 {
     color: var(--secondary);
 }
 
+#word-container {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+}
+
 #word-display {
     font-size: 2em;
     margin: 20px 0;
     color: var(--primary);
     text-shadow: 0 2px 4px rgba(0,0,0,0.15);
     font-weight: bold;
+}
+
+#word-display.hidden {
+    display: none;
+}
+
+#toggle-word {
+    background: none;
+    border: none;
+    cursor: pointer;
+    font-size: 1.5em;
+    margin-top: -10px;
 }
 
 
@@ -219,5 +237,9 @@ select {
         font-size: 0.9em;
         margin: 3px 0;
         width: 100%;
+    }
+
+    #toggle-word {
+        font-size: 1.2em;
     }
 }


### PR DESCRIPTION
## Summary
- let players hide/reveal the word with an eye button
- reset timer and word when starting a new game or returning to menu
- add helper to reset the UI
- update styles for the new toggle

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6840c9c87dbc83228c8b2436fd9eb365