### PR TITLE
Améliorations menu joueurs et changement de mot

### DIFF
--- a/index.html
+++ b/index.html
@@ -36,7 +36,10 @@
 
         <div id="word-container">
             <div id="word-display">Appuyez sur "Nouvelle manche"</div>
-            <button id="toggle-word" style="display:none" title="Afficher le mot">👁️</button>
+            <div id="word-actions">
+                <button id="toggle-word" style="display:none" title="Afficher le mot">👁️</button>
+                <button id="change-word" style="display:none" title="Changer de mot">🔄</button>
+            </div>
         </div>
 
         <div id="timer">0</div>

--- a/script.js
+++ b/script.js
@@ -41,14 +41,19 @@ function renderConfig() {
     const container = document.getElementById('teams-config');
     container.innerHTML = '';
 
-    const datalist = document.createElement('datalist');
-    datalist.id = 'players-datalist';
+    let datalist = document.getElementById('players-datalist');
+    if (!datalist) {
+        datalist = document.createElement('datalist');
+        datalist.id = 'players-datalist';
+        document.body.appendChild(datalist);
+    } else {
+        datalist.innerHTML = '';
+    }
     Object.keys(players).forEach(name => {
         const option = document.createElement('option');
         option.value = name;
         datalist.appendChild(option);
     });
-    container.appendChild(datalist);
 
     teams.forEach((team, tIdx) => {
         const div = document.createElement('div');
@@ -113,7 +118,7 @@ function updatePlayerSelect() {
         team.players.forEach((player, pIdx) => {
             const option = document.createElement('option');
             option.value = `${tIdx}-${pIdx}`;
-            option.textContent = `${player.name} - ${team.name}`;
+            option.textContent = player.name;
             select.appendChild(option);
         });
     });
@@ -136,6 +141,7 @@ function startRound() {
     void wordDisplay.offsetWidth;
     wordDisplay.classList.add('flash');
     document.getElementById('toggle-word').style.display = 'block';
+    document.getElementById('change-word').style.display = 'block';
 
     elapsedSeconds = 0;
     document.getElementById('timer').textContent = elapsedSeconds;
@@ -147,6 +153,19 @@ function startRound() {
         elapsedSeconds++;
         document.getElementById('timer').textContent = elapsedSeconds;
     }, 1000);
+}
+
+function changeWord() {
+    currentWord = defaultWords[Math.floor(Math.random() * defaultWords.length)];
+    const wordDisplay = document.getElementById('word-display');
+    const hidden = wordDisplay.classList.contains('hidden');
+    wordDisplay.textContent = currentWord;
+    wordDisplay.classList.remove('flash');
+    void wordDisplay.offsetWidth;
+    wordDisplay.classList.add('flash');
+    if (hidden) {
+        wordDisplay.classList.add('hidden');
+    }
 }
 
 function endRound() {
@@ -175,6 +194,7 @@ function endRound() {
     wordDisplay.classList.remove('flash');
     wordDisplay.classList.remove('hidden');
     document.getElementById('toggle-word').style.display = 'none';
+    document.getElementById('change-word').style.display = 'none';
     document.getElementById('timer').textContent = elapsedSeconds;
 }
 
@@ -188,6 +208,7 @@ function resetGameUI() {
     wordDisplay.classList.remove('flash');
     wordDisplay.classList.remove('hidden');
     document.getElementById('toggle-word').style.display = 'none';
+    document.getElementById('change-word').style.display = 'none';
     document.getElementById('word-found').disabled = true;
     document.getElementById('start').disabled = false;
 }
@@ -251,6 +272,8 @@ document.getElementById('start').addEventListener('click', startRound);
 document.getElementById('toggle-word').addEventListener('click', () => {
     document.getElementById('word-display').classList.toggle('hidden');
 });
+
+document.getElementById('change-word').addEventListener('click', changeWord);
 
 document.getElementById('word-found').addEventListener('click', endRound);
 

--- a/style.css
+++ b/style.css
@@ -133,6 +133,21 @@ h1 {
     margin-top: -10px;
 }
 
+#change-word {
+    background: none;
+    border: none;
+    cursor: pointer;
+    font-size: 1.5em;
+    margin-top: -10px;
+    margin-left: 5px;
+}
+
+#word-actions {
+    display: flex;
+    align-items: center;
+    gap: 5px;
+}
+
 
 #controls {
     display: flex;


### PR DESCRIPTION
## Notes
- Le menu de sélection des joueurs propose désormais uniquement les noms, et la datalist est correctement reconstruite.
- Ajout d'un bouton "changer de mot" pour passer au mot suivant en cours de manche.
- Mise à jour des styles correspondants.

------
https://chatgpt.com/codex/tasks/task_e_6840cd7d9db08322bdebc7b044c37437