### PR TITLE
Improve scoreboard design

### DIFF
--- a/style.css
+++ b/style.css
@@ -60,11 +60,11 @@ h1 {
     color: var(--secondary);
 }
 #scoreboard {
-    display: flex;
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
     background: rgba(255, 255, 255, 0.6);
     padding: 10px;
     border-radius: 12px;
-    justify-content: space-between;
     margin-bottom: 20px;
     gap: 10px;
     backdrop-filter: blur(4px);
@@ -78,12 +78,13 @@ h1 {
     border-radius: 10px;
     box-shadow: 0 3px 8px rgba(0, 0, 0, 0.15);
     border: 1px solid rgba(255, 255, 255, 0.2);
-    transition: transform 0.3s ease, box-shadow 0.3s ease;
+    transition: transform 0.3s ease, box-shadow 0.3s ease, background 0.3s ease;
 }
 
 .team:hover {
     transform: translateY(-4px);
     box-shadow: 0 6px 12px rgba(0, 0, 0, 0.2);
+    background: linear-gradient(to bottom right, var(--secondary), #0f172a);
 }
 .team .players {
     margin-top: 10px;
@@ -103,12 +104,14 @@ h1 {
     border: 3px solid var(--accent);
     transform: scale(1.05);
     box-shadow: 0 0 15px var(--accent);
+    transition: transform 0.3s ease, box-shadow 0.3s ease;
 }
 
 .score {
     font-size: 2.2em;
     display: block;
     margin-top: 5px;
+    text-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
 }
 
 #active-team {
@@ -249,7 +252,7 @@ select {
     }
 
     #scoreboard {
-        flex-direction: column;
+        grid-template-columns: 1fr;
     }
 
     #controls {


### PR DESCRIPTION
## Summary
- revamp scoreboard layout to use CSS grid
- add transitions and text shadows for teams and scores
- tweak responsive design for scoreboard on small screens

## Testing
- `npm test` *(fails: Could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68419f0b78c88322aa600c6f8818e9cc