### PR TITLE
Add dark mode toggle

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,6 +8,7 @@
     <link rel="stylesheet" href="style.css">
 </head>
 <body>
+    <button id="theme-toggle" title="Changer de thème">🌙</button>
     <div id="config-container" class="container">
         <h1>Configuration de la partie</h1>
         <div id="setup">

--- a/script.js
+++ b/script.js
@@ -10,6 +10,7 @@ let activeTeamIndex = 0;
 let timer;
 let elapsedSeconds = 0;
 let currentWord = '';
+let currentTheme = 'light';
 
 function loadState() {
     const data = localStorage.getItem('teams');
@@ -28,6 +29,10 @@ function loadState() {
     if (!isNaN(active)) {
         activeTeamIndex = active;
     }
+    const theme = localStorage.getItem('theme');
+    if (theme) {
+        currentTheme = theme;
+    }
 }
 
 function saveState() {
@@ -35,6 +40,15 @@ function saveState() {
     localStorage.setItem('players', JSON.stringify(players));
     localStorage.setItem('history', JSON.stringify(history));
     localStorage.setItem('activeTeamIndex', activeTeamIndex);
+    localStorage.setItem('theme', currentTheme);
+}
+
+function applyTheme() {
+    document.body.classList.toggle('dark', currentTheme === 'dark');
+    const btn = document.getElementById('theme-toggle');
+    if (btn) {
+        btn.textContent = currentTheme === 'dark' ? '☀️' : '🌙';
+    }
 }
 
 function renderConfig() {
@@ -292,9 +306,15 @@ document.getElementById('menu-btn').addEventListener('click', () => {
     document.getElementById('config-container').style.display = 'block';
 });
 
-loadState();
-renderConfig();
+document.getElementById('theme-toggle').addEventListener('click', () => {
+    currentTheme = currentTheme === 'dark' ? 'light' : 'dark';
+    applyTheme();
+    saveState();
+});
 
+loadState();
+applyTheme();
+renderConfig();
 resetGameUI();
 
 document.getElementById('game-container').style.display = 'none';

--- a/style.css
+++ b/style.css
@@ -7,6 +7,29 @@
     --accent-light: #fecaca;
     --container-bg1: rgba(255, 255, 255, 0.85);
     --container-bg2: rgba(255, 255, 255, 0.65);
+    --team-end: #1e293b;
+    --team-hover-end: #0f172a;
+    --button-secondary: #4338ca;
+    --timer-bg: #fff;
+    --input-border: #ccc;
+    --text-light: #fff;
+}
+
+:root.dark {
+    --primary: #8b5cf6;
+    --secondary: #e2e8f0;
+    --accent: #f87171;
+    --bg-start: #0f172a;
+    --bg-end: #1e293b;
+    --accent-light: #fca5a5;
+    --container-bg1: rgba(30, 41, 59, 0.85);
+    --container-bg2: rgba(17, 24, 39, 0.65);
+    --team-end: #475569;
+    --team-hover-end: #334155;
+    --button-secondary: #4338ca;
+    --timer-bg: #1e293b;
+    --input-border: #475569;
+    --text-light: #e2e8f0;
 }
 
 body {
@@ -18,6 +41,22 @@ body {
     display: flex;
     align-items: center;
     justify-content: center;
+}
+
+#theme-toggle {
+    position: fixed;
+    top: 10px;
+    right: 10px;
+    background: none;
+    border: none;
+    font-size: 1.5em;
+    cursor: pointer;
+    color: var(--secondary);
+    z-index: 1000;
+}
+
+body.dark #theme-toggle {
+    color: var(--accent-light);
 }
 
 .container {
@@ -72,8 +111,8 @@ h1 {
 
 .team {
     flex: 1;
-    background: linear-gradient(to bottom right, var(--secondary), #1e293b);
-    color: #fff;
+    background: linear-gradient(to bottom right, var(--secondary), var(--team-end));
+    color: var(--text-light);
     padding: 20px 15px;
     border-radius: 10px;
     box-shadow: 0 3px 8px rgba(0, 0, 0, 0.15);
@@ -84,7 +123,7 @@ h1 {
 .team:hover {
     transform: translateY(-4px);
     box-shadow: 0 6px 12px rgba(0, 0, 0, 0.2);
-    background: linear-gradient(to bottom right, var(--secondary), #0f172a);
+    background: linear-gradient(to bottom right, var(--secondary), var(--team-hover-end));
 }
 .team .players {
     margin-top: 10px;
@@ -173,7 +212,7 @@ h1 {
     margin: 10px 0;
     color: var(--accent);
     padding: 8px 12px;
-    background: #fff;
+    background: var(--timer-bg);
     border: 2px solid var(--accent-light);
     border-radius: 8px;
     display: inline-block;
@@ -184,8 +223,8 @@ button {
     margin: 5px;
     border: none;
     border-radius: 6px;
-    background: linear-gradient(to bottom, var(--primary), #4338ca);
-    color: #fff;
+    background: linear-gradient(to bottom, var(--primary), var(--button-secondary));
+    color: var(--text-light);
     box-shadow: 0 3px 8px rgba(0, 0, 0, 0.1);
     transition: background 0.3s ease, transform 0.2s ease, box-shadow 0.3s ease;
 }
@@ -205,7 +244,7 @@ input[type="number"],
 input[type="text"],
 select {
     padding: 8px 12px;
-    border: 1px solid #ccc;
+    border: 1px solid var(--input-border);
     border-radius: 6px;
     margin-top: 5px;
 }


### PR DESCRIPTION
## Summary
- add a theme toggle button to switch between light and dark mode
- implement theme persistence with localStorage
- refactor styles to support dark theme via CSS variables

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6841a0e1aec8832281129b07fcd33a5e