### PR TITLE
Add game history modal

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,3 +29,7 @@ Le jeu s’affiche alors directement dans le navigateur et peut être utilisé h
 - **Mot trouvé** : après avoir sélectionné le joueur gagnant, arrête le chronomètre et ajoute un point au joueur et à son équipe.
 - L’équipe actuellement active est indiquée sous le tableau de scores et la case de cette équipe est encadrée d’une bordure colorée.
 - **Réinitialiser les scores** : remet les scores de tous les joueurs et équipes à zéro.
+- **Historique** : affiche la liste des parties précédentes et permet de vider cette liste.
+
+## Historique des parties
+L'application mémorise localement chaque partie terminée. Le bouton **Historique** ouvre une fenêtre récapitulative indiquant la date et le score de chaque équipe. Depuis cette fenêtre, vous pouvez également effacer toutes les données enregistrées.

--- a/index.html
+++ b/index.html
@@ -26,6 +26,7 @@
         </div>
         <div id="teams-config"></div>
         <button id="start-game" disabled>Commencer la partie</button>
+        <button id="show-history-config">Historique</button>
     </div>
 
     <div id="game-container" class="container">
@@ -51,6 +52,15 @@
             <button id="word-found" disabled>Mot trouvé</button>
             <button id="reset-scores">Réinitialiser les scores</button>
             <button id="menu-btn">Menu</button>
+            <button id="show-history-game">Historique</button>
+        </div>
+    </div>
+    <div id="history-modal" class="modal" style="display:none">
+        <div class="modal-content">
+            <h2>Historique des parties</h2>
+            <div id="history-list"></div>
+            <button id="clear-history">Effacer l'historique</button>
+            <button id="close-history">Fermer</button>
         </div>
     </div>
     <script src="script.js"></script>

--- a/script.js
+++ b/script.js
@@ -308,6 +308,44 @@ document.getElementById('menu-btn').addEventListener('click', () => {
     document.getElementById('config-container').style.display = 'block';
 });
 
+function renderHistory() {
+    const list = document.getElementById('history-list');
+    if (!list) return;
+    list.innerHTML = '';
+    if (history.length === 0) {
+        list.textContent = 'Aucune partie enregistrée.';
+        return;
+    }
+    history.slice().reverse().forEach(game => {
+        const div = document.createElement('div');
+        const date = new Date(game.date).toLocaleString();
+        const scores = game.teams.map(t => `${t.name}: ${t.score || 0}`).join(', ');
+        div.textContent = `${date} - ${scores}`;
+        list.appendChild(div);
+    });
+}
+
+function showHistory() {
+    renderHistory();
+    document.getElementById('history-modal').style.display = 'flex';
+}
+
+function closeHistory() {
+    document.getElementById('history-modal').style.display = 'none';
+}
+
+document.querySelectorAll('#show-history-config, #show-history-game').forEach(btn => {
+    if (btn) btn.addEventListener('click', showHistory);
+});
+
+document.getElementById('close-history').addEventListener('click', closeHistory);
+
+document.getElementById('clear-history').addEventListener('click', () => {
+    history = [];
+    saveState();
+    renderHistory();
+});
+
 document.getElementById('theme-toggle').addEventListener('click', () => {
     currentTheme = currentTheme === 'dark' ? 'light' : 'dark';
     applyTheme();

--- a/style.css
+++ b/style.css
@@ -310,3 +310,32 @@ select {
         font-size: 1.2em;
     }
 }
+
+.modal {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background: rgba(0, 0, 0, 0.5);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 2000;
+}
+
+.modal-content {
+    background: linear-gradient(to bottom right, var(--container-bg1), var(--container-bg2));
+    padding: 20px;
+    border-radius: 12px;
+    max-width: 400px;
+    width: 90%;
+    color: var(--secondary);
+}
+
+#history-list {
+    text-align: left;
+    max-height: 300px;
+    overflow-y: auto;
+    margin-bottom: 10px;
+}


### PR DESCRIPTION
## Summary
- add buttons to display history of previous games
- style and layout modal popup
- implement history rendering and clearing
- document how to view and clear saved game history

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6841a6a081988322ba739b2a6ddb98c8