### PR TITLE
Add player stats modal

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,10 @@ Le jeu s’affiche alors directement dans le navigateur et peut être utilisé h
 - L’équipe actuellement active est indiquée sous le tableau de scores et la case de cette équipe est encadrée d’une bordure colorée.
 - **Réinitialiser les scores** : remet les scores de tous les joueurs et équipes à zéro.
 - **Historique** : affiche la liste des parties précédentes et permet de vider cette liste.
+- **Stats** : affiche les statistiques cumulées de tous les joueurs enregistrés.
 
 ## Historique des parties
 L'application mémorise localement chaque partie terminée. Le bouton **Historique** ouvre une fenêtre récapitulative indiquant la date et le score de chaque équipe. Depuis cette fenêtre, vous pouvez également effacer toutes les données enregistrées.
+
+## Statistiques des joueurs
+Le bouton **Stats** affiche un classement des joueurs enregistrés avec le nombre total de points accumulés et le nombre de parties jouées. Vous pouvez remettre ces statistiques à zéro depuis cette même fenêtre.

--- a/index.html
+++ b/index.html
@@ -27,6 +27,7 @@
         <div id="teams-config"></div>
         <button id="start-game" disabled>Commencer la partie</button>
         <button id="show-history-config">Historique</button>
+        <button id="show-stats-config">Stats</button>
     </div>
 
     <div id="game-container" class="container">
@@ -53,6 +54,7 @@
             <button id="reset-scores">Réinitialiser les scores</button>
             <button id="menu-btn">Menu</button>
             <button id="show-history-game">Historique</button>
+            <button id="show-stats-game">Stats</button>
         </div>
     </div>
     <div id="history-modal" class="modal" style="display:none">
@@ -61,6 +63,14 @@
             <div id="history-list"></div>
             <button id="clear-history">Effacer l'historique</button>
             <button id="close-history">Fermer</button>
+        </div>
+    </div>
+    <div id="stats-modal" class="modal" style="display:none">
+        <div class="modal-content">
+            <h2>Classement des joueurs</h2>
+            <div id="stats-list"></div>
+            <button id="clear-stats">Réinitialiser les stats</button>
+            <button id="close-stats">Fermer</button>
         </div>
     </div>
     <script src="script.js"></script>

--- a/script.js
+++ b/script.js
@@ -346,6 +346,45 @@ document.getElementById('clear-history').addEventListener('click', () => {
     renderHistory();
 });
 
+function renderStats() {
+    const list = document.getElementById('stats-list');
+    if (!list) return;
+    list.innerHTML = '';
+    const playersArr = Object.values(players).sort((a, b) => (b.totalScore || 0) - (a.totalScore || 0));
+    if (playersArr.length === 0) {
+        list.textContent = 'Aucun joueur enregistr\u00e9.';
+        return;
+    }
+    playersArr.forEach(p => {
+        const div = document.createElement('div');
+        const games = p.gamesPlayed || 0;
+        const score = p.totalScore || 0;
+        div.textContent = `${p.name}: ${score} point(s) en ${games} partie(s)`;
+        list.appendChild(div);
+    });
+}
+
+function showStats() {
+    renderStats();
+    document.getElementById('stats-modal').style.display = 'flex';
+}
+
+function closeStats() {
+    document.getElementById('stats-modal').style.display = 'none';
+}
+
+document.querySelectorAll('#show-stats-config, #show-stats-game').forEach(btn => {
+    if (btn) btn.addEventListener('click', showStats);
+});
+
+document.getElementById('close-stats').addEventListener('click', closeStats);
+
+document.getElementById('clear-stats').addEventListener('click', () => {
+    players = {};
+    saveState();
+    renderStats();
+});
+
 document.getElementById('theme-toggle').addEventListener('click', () => {
     currentTheme = currentTheme === 'dark' ? 'light' : 'dark';
     applyTheme();

--- a/style.css
+++ b/style.css
@@ -339,3 +339,9 @@ select {
     overflow-y: auto;
     margin-bottom: 10px;
 }
+#stats-list {
+    text-align: left;
+    max-height: 300px;
+    overflow-y: auto;
+    margin-bottom: 10px;
+}


### PR DESCRIPTION
## Summary
- display cumulative player statistics
- update UI with stats buttons and modal
- style stats list similar to history
- document the new feature

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6841a826579883229446ea6ae1f244e6