### PR TITLE
Implement customizable word list

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,10 @@ Le jeu s’affiche alors directement dans le navigateur et peut être utilisé h
 - **index.html** : structure de la page et des éléments du jeu (scores, boutons, etc.).
 - **style.css** : mise en forme de l’interface (positionnement, couleurs et typographie).
 - **script.js** : logique du jeu : tirage des mots aléatoires, gestion du minuteur, des scores et de l’équipe active.
+- **words.js** : liste de mots utilisée pour les manches. Vous pouvez y ajouter facilement des centaines ou milliers de mots supplémentaires.
+
+### Personnaliser la liste de mots
+Modifiez le fichier `words.js` pour insérer votre propre liste de mots (plusieurs milliers si nécessaire). Le script chargera automatiquement cette liste au démarrage du jeu.
 
 ## Commandes et interface
 - **Ajouter une équipe** / **Ajouter un joueur** : permettent de préparer la partie sur l’écran de configuration.

--- a/index.html
+++ b/index.html
@@ -73,6 +73,7 @@
             <button id="close-stats">Fermer</button>
         </div>
     </div>
+    <script src="words.js"></script>
     <script src="script.js"></script>
 </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -1,7 +1,9 @@
-const defaultWords = [
-    'Chat', 'Chocolat', 'Avion', 'Pyramide', 'Pirate',
-    'Bateau', 'Arc-en-ciel', 'Licorne', 'Robot', 'Montagne'
-];
+const defaultWords = typeof window !== 'undefined' && Array.isArray(window.wordList) && window.wordList.length
+  ? window.wordList
+  : [
+      'Chat', 'Chocolat', 'Avion', 'Pyramide', 'Pirate',
+      'Bateau', 'Arc-en-ciel', 'Licorne', 'Robot', 'Montagne'
+    ];
 
 let teams = [];
 let players = {};

--- a/words.js
+++ b/words.js
@@ -1,0 +1,22 @@
+window.wordList = [
+  'Chat', 'Chien', 'Voiture', 'Avion', 'Maison',
+  'Ordinateur', 'Livre', 'Pomme', 'Montagne', 'Océan',
+  'Soleil', 'Lune', 'Étoile', 'Rivière', 'Forêt',
+  'Neige', 'Pluie', 'Tempête', 'Arc', 'Fleur',
+  'Désert', 'Ferme', 'Route', 'Train', 'Bateau',
+  'Pirate', 'Robot', 'Chocolat', 'Musique', 'Guitare',
+  'Piano', 'Tambour', 'Danse', 'Cheval', 'Souris',
+  'Lumière', 'Ombre', 'Valise', 'Voyage', 'Café',
+  'Thé', 'Bonbon', 'Nuage', 'Vent', 'Chanson',
+  'Poésie', 'Ciel', 'Parapluie', 'Fauteuil', 'Chaise',
+  'Table', 'Téléphone', 'Radio', 'Journal', 'Carte',
+  'Photo', 'Film', 'Théâtre', 'Hôtel', 'Magasin',
+  'École', 'Université', 'Boulangerie', 'Bouteille', 'Verre',
+  'Cuisine', 'Salon', 'Jardin', 'Parc', 'Ville',
+  'Village', 'Pays', 'Continent', 'Planète', 'Galaxie',
+  'Univers', 'Voyageur', 'Explorateur', 'Héros', 'Princesse',
+  'Dragon', 'Monstre', 'Trésor', 'Cascade', 'Plage',
+  'Vacances', 'Robotique', 'Science', 'Histoire', 'Art',
+  'Peinture', 'Sculpture', 'Architecte', 'Ingénieur', 'Médecin',
+  'Professeur', 'Student', 'Bureau', 'Ami', 'Famille'
+];


### PR DESCRIPTION
## Summary
- load words from new `words.js` if provided
- include `words.js` in the page
- add sample word list
- document how to customize the list

## Testing
- `node --check script.js`
- `node --check words.js`

------
https://chatgpt.com/codex/tasks/task_e_6841a9a0ee1c83228c42656daeac4fbf