### PR TITLE
Enhance player info with registration date

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,10 +34,10 @@ Modifiez le fichier `words.js` pour insérer votre propre liste de mots (plusieu
 - L’équipe actuellement active est indiquée sous le tableau de scores et la case de cette équipe est encadrée d’une bordure colorée.
 - **Réinitialiser les scores** : remet les scores de tous les joueurs et équipes à zéro.
 - **Historique** : affiche la liste des parties précédentes et permet de vider cette liste.
-- **Stats** : affiche les statistiques cumulées de tous les joueurs enregistrés.
+- **Stats** : affiche pour chaque joueur son score total, le nombre de parties jouées et sa date d'inscription.
 
 ## Historique des parties
 L'application mémorise localement chaque partie terminée. Le bouton **Historique** ouvre une fenêtre récapitulative indiquant la date et le score de chaque équipe. Depuis cette fenêtre, vous pouvez également effacer toutes les données enregistrées.
 
 ## Statistiques des joueurs
-Le bouton **Stats** affiche un classement des joueurs enregistrés avec le nombre total de points accumulés et le nombre de parties jouées. Vous pouvez remettre ces statistiques à zéro depuis cette même fenêtre.
+Le bouton **Stats** affiche un classement des joueurs enregistrés avec leur date d'inscription, le nombre total de points accumulés et le nombre de parties jouées. Vous pouvez remettre ces statistiques à zéro depuis cette même fenêtre.

--- a/script.js
+++ b/script.js
@@ -14,6 +14,11 @@ let elapsedSeconds = 0;
 let currentWord = '';
 let currentTheme = 'light';
 
+function createPlayer(name) {
+    return { name, totalScore: 0, gamesPlayed: 0, createdAt: new Date().toISOString() };
+}
+
+
 function loadState() {
     const data = localStorage.getItem('teams');
     if (data) {
@@ -22,6 +27,7 @@ function loadState() {
     const pData = localStorage.getItem('players');
     if (pData) {
         players = JSON.parse(pData);
+        Object.values(players).forEach(p => { if (!p.createdAt) p.createdAt = new Date().toISOString(); });
     }
     const hData = localStorage.getItem('history');
     if (hData) {
@@ -261,7 +267,7 @@ document.getElementById('start-game').addEventListener('click', () => {
             const name = input.value.trim();
             if (name) {
                 if (!players[name]) {
-                    players[name] = { name, totalScore: 0, gamesPlayed: 0 };
+                    players[name] = createPlayer(name);
                 }
                 team.players.push({ name, score: 0 });
             }
@@ -361,7 +367,7 @@ function renderStats() {
         const div = document.createElement('div');
         const games = p.gamesPlayed || 0;
         const score = p.totalScore || 0;
-        div.textContent = `${p.name}: ${score} point(s) en ${games} partie(s)`;
+        div.textContent = `${p.name} (inscrit le ${new Date(p.createdAt).toLocaleDateString()}) : ${score} point(s) en ${games} partie(s)`;
         list.appendChild(div);
     });
 }


### PR DESCRIPTION
## Summary
- track detailed player info with a creation date
- display registration date in stats modal
- update docs about new player information

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6841ac3d1b54832297df4e9a4c36da6e