### PR TITLE
Amélioration des stats et de l'historique

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,5 +42,7 @@ L'application mémorise localement chaque partie terminée. Le bouton **Historiq
 ## Statistiques des joueurs
 Le bouton **Stats** affiche un classement des joueurs enregistrés avec leur date d'inscription, le nombre total de points accumulés et le nombre de parties jouées. Vous pouvez remettre ces statistiques à zéro depuis cette même fenêtre.
 
+Les fenêtres d'historique et de statistiques adoptent désormais un style différent selon qu'elles sont ouvertes depuis le menu ou au cours d'une partie, afin de mieux distinguer les données globales de celles liées à la partie en cours.
+
 ## Design amélioré
 La feuille de style a été retravaillée afin d'offrir une interface plus claire et plus agréable. Les équipes sont mieux mises en valeur sur le tableau de score et le bouton permettant de changer de thème dispose d'une étiquette d'accessibilité.

--- a/index.html
+++ b/index.html
@@ -57,22 +57,22 @@
             <button id="show-stats-game">Stats</button>
         </div>
     </div>
-    <div id="history-modal" class="modal" style="display:none">
-        <div class="modal-content">
-            <h2>Historique des parties</h2>
-            <div id="history-list"></div>
-            <button id="clear-history">Effacer l'historique</button>
-            <button id="close-history">Fermer</button>
+        <div id="history-modal" class="modal" style="display:none">
+            <div class="modal-content menu" id="history-content">
+                <h2 id="history-title">Historique des parties</h2>
+                <ul id="history-list"></ul>
+                <button id="clear-history">Effacer l'historique</button>
+                <button id="close-history">Fermer</button>
+            </div>
         </div>
-    </div>
-    <div id="stats-modal" class="modal" style="display:none">
-        <div class="modal-content">
-            <h2>Classement des joueurs</h2>
-            <div id="stats-list"></div>
-            <button id="clear-stats">Réinitialiser les stats</button>
-            <button id="close-stats">Fermer</button>
+        <div id="stats-modal" class="modal" style="display:none">
+            <div class="modal-content menu" id="stats-content">
+                <h2 id="stats-title">Classement des joueurs</h2>
+                <ul id="stats-list"></ul>
+                <button id="clear-stats">Réinitialiser les stats</button>
+                <button id="close-stats">Fermer</button>
+            </div>
         </div>
-    </div>
     <script src="words.js"></script>
     <script src="script.js"></script>
 </body>

--- a/script.js
+++ b/script.js
@@ -321,30 +321,41 @@ function renderHistory() {
     if (!list) return;
     list.innerHTML = '';
     if (history.length === 0) {
-        list.textContent = 'Aucune partie enregistrée.';
+        const li = document.createElement('li');
+        li.textContent = 'Aucune partie enregistrée.';
+        list.appendChild(li);
         return;
     }
     history.slice().reverse().forEach(game => {
-        const div = document.createElement('div');
+        const li = document.createElement('li');
         const date = new Date(game.date).toLocaleString();
         const scores = game.teams.map(t => `${t.name}: ${t.score || 0}`).join(', ');
-        div.textContent = `${date} - ${scores}`;
-        list.appendChild(div);
+        li.textContent = `${date} - ${scores}`;
+        list.appendChild(li);
     });
 }
 
-function showHistory() {
+function showHistory(context) {
     renderHistory();
-    document.getElementById('history-modal').style.display = 'flex';
+    const modal = document.getElementById('history-modal');
+    const content = document.getElementById('history-content');
+    const title = document.getElementById('history-title');
+    modal.style.display = 'flex';
+    content.classList.toggle('game', context === 'game');
+    content.classList.toggle('menu', context !== 'game');
+    if (title) {
+        title.textContent = context === 'game' ? 'Historique de la partie' : 'Historique des parties';
+    }
 }
 
 function closeHistory() {
     document.getElementById('history-modal').style.display = 'none';
 }
 
-document.querySelectorAll('#show-history-config, #show-history-game').forEach(btn => {
-    if (btn) btn.addEventListener('click', showHistory);
-});
+const historyConfigBtn = document.getElementById('show-history-config');
+if (historyConfigBtn) historyConfigBtn.addEventListener('click', () => showHistory('menu'));
+const historyGameBtn = document.getElementById('show-history-game');
+if (historyGameBtn) historyGameBtn.addEventListener('click', () => showHistory('game'));
 
 document.getElementById('close-history').addEventListener('click', closeHistory);
 
@@ -360,30 +371,41 @@ function renderStats() {
     list.innerHTML = '';
     const playersArr = Object.values(players).sort((a, b) => (b.totalScore || 0) - (a.totalScore || 0));
     if (playersArr.length === 0) {
-        list.textContent = 'Aucun joueur enregistr\u00e9.';
+        const li = document.createElement('li');
+        li.textContent = 'Aucun joueur enregistr\u00e9.';
+        list.appendChild(li);
         return;
     }
     playersArr.forEach(p => {
-        const div = document.createElement('div');
+        const li = document.createElement('li');
         const games = p.gamesPlayed || 0;
         const score = p.totalScore || 0;
-        div.textContent = `${p.name} (inscrit le ${new Date(p.createdAt).toLocaleDateString()}) : ${score} point(s) en ${games} partie(s)`;
-        list.appendChild(div);
+        li.textContent = `${p.name} (inscrit le ${new Date(p.createdAt).toLocaleDateString()}) : ${score} point(s) en ${games} partie(s)`;
+        list.appendChild(li);
     });
 }
 
-function showStats() {
+function showStats(context) {
     renderStats();
-    document.getElementById('stats-modal').style.display = 'flex';
+    const modal = document.getElementById('stats-modal');
+    const content = document.getElementById('stats-content');
+    const title = document.getElementById('stats-title');
+    modal.style.display = 'flex';
+    content.classList.toggle('game', context === 'game');
+    content.classList.toggle('menu', context !== 'game');
+    if (title) {
+        title.textContent = context === 'game' ? 'Stats de la partie' : 'Classement des joueurs';
+    }
 }
 
 function closeStats() {
     document.getElementById('stats-modal').style.display = 'none';
 }
 
-document.querySelectorAll('#show-stats-config, #show-stats-game').forEach(btn => {
-    if (btn) btn.addEventListener('click', showStats);
-});
+const statsConfigBtn = document.getElementById('show-stats-config');
+if (statsConfigBtn) statsConfigBtn.addEventListener('click', () => showStats('menu'));
+const statsGameBtn = document.getElementById('show-stats-game');
+if (statsGameBtn) statsGameBtn.addEventListener('click', () => showStats('game'));
 
 document.getElementById('close-stats').addEventListener('click', closeStats);
 

--- a/style.css
+++ b/style.css
@@ -336,6 +336,12 @@ select {
     width: 90%;
     color: var(--secondary);
 }
+.modal-content.menu {
+    border-top: 4px solid var(--primary);
+}
+.modal-content.game {
+    border-top: 4px solid var(--accent);
+}
 
 #history-list {
     text-align: left;
@@ -343,9 +349,21 @@ select {
     overflow-y: auto;
     margin-bottom: 10px;
 }
+#history-list li {
+    padding: 4px 6px;
+    margin-bottom: 4px;
+    background: rgba(0, 0, 0, 0.05);
+    border-radius: 6px;
+}
 #stats-list {
     text-align: left;
     max-height: 300px;
     overflow-y: auto;
     margin-bottom: 10px;
+}
+#stats-list li {
+    padding: 4px 6px;
+    margin-bottom: 4px;
+    background: rgba(0, 0, 0, 0.05);
+    border-radius: 6px;
 }


### PR DESCRIPTION
## Notes
- Ajout d'un affichage différent pour l'historique et les statistiques selon que l'on se trouve dans le menu ou pendant la partie.
- Les listes sont maintenant des `<ul>` avec un style plus travaillé.
- Mise à jour du script pour gérer ces nouveaux styles et textes.
- README mis à jour pour mentionner cette différenciation.

------
https://chatgpt.com/codex/tasks/task_e_6842d14f37fc8322918e09ca8b7d1164