### PR TITLE
Improve history management

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,10 +34,12 @@ Modifiez le fichier `words.js` pour insérer votre propre liste de mots (plusieu
 - L’équipe actuellement active est indiquée sous le tableau de scores et la case de cette équipe est encadrée d’une bordure colorée.
 - **Réinitialiser les scores** : remet les scores de tous les joueurs et équipes à zéro.
 - **Historique** : affiche la liste des parties précédentes et permet de vider cette liste.
+- **Exporter / Importer l'historique** : permet de sauvegarder ou charger les parties enregistrées au format JSON.
 - **Stats** : affiche pour chaque joueur son score total, le nombre de parties jouées et sa date d'inscription.
 
 ## Historique des parties
 L'application mémorise localement chaque partie terminée. Le bouton **Historique** ouvre une fenêtre récapitulative indiquant la date et le score de chaque équipe. Depuis cette fenêtre, vous pouvez également effacer toutes les données enregistrées.
+Il est désormais possible d'exporter cet historique au format JSON ou de le réimporter ultérieurement.
 
 ## Statistiques des joueurs
 Le bouton **Stats** affiche un classement des joueurs enregistrés avec leur date d'inscription, le nombre total de points accumulés et le nombre de parties jouées. Vous pouvez remettre ces statistiques à zéro depuis cette même fenêtre.

--- a/index.html
+++ b/index.html
@@ -61,6 +61,11 @@
             <div class="modal-content menu" id="history-content">
                 <h2 id="history-title">Historique des parties</h2>
                 <ul id="history-list"></ul>
+                <div class="history-actions">
+                    <button id="export-history">Exporter</button>
+                    <button id="import-history">Importer</button>
+                    <input type="file" id="import-history-file" accept="application/json" style="display:none">
+                </div>
                 <button id="clear-history">Effacer l'historique</button>
                 <button id="close-history">Fermer</button>
             </div>

--- a/script.js
+++ b/script.js
@@ -365,6 +365,44 @@ document.getElementById('clear-history').addEventListener('click', () => {
     renderHistory();
 });
 
+function exportHistory() {
+    const blob = new Blob([JSON.stringify(history, null, 2)], { type: 'application/json' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = 'history.json';
+    a.click();
+    URL.revokeObjectURL(url);
+}
+
+function handleImportHistory(event) {
+    const file = event.target.files[0];
+    if (!file) return;
+    const reader = new FileReader();
+    reader.onload = () => {
+        try {
+            const data = JSON.parse(reader.result);
+            if (Array.isArray(data)) {
+                history = data;
+                saveState();
+                renderHistory();
+            } else {
+                alert('Fichier invalide');
+            }
+        } catch (e) {
+            alert('Fichier invalide');
+        }
+    };
+    reader.readAsText(file);
+    event.target.value = '';
+}
+
+document.getElementById('export-history').addEventListener('click', exportHistory);
+document.getElementById('import-history').addEventListener('click', () => {
+    document.getElementById('import-history-file').click();
+});
+document.getElementById('import-history-file').addEventListener('change', handleImportHistory);
+
 function renderStats() {
     const list = document.getElementById('stats-list');
     if (!list) return;

--- a/style.css
+++ b/style.css
@@ -355,6 +355,11 @@ select {
     background: rgba(0, 0, 0, 0.05);
     border-radius: 6px;
 }
+.history-actions {
+    display: flex;
+    justify-content: space-between;
+    margin-bottom: 10px;
+}
 #stats-list {
     text-align: left;
     max-height: 300px;


### PR DESCRIPTION
## Summary
- add export and import buttons to history modal
- support import/export logic in script
- style history action buttons
- document new import/export capability

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6842d3fabd0883229750620fa6d59140