### PR TITLE
Add in-game rules modal

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Modifiez le fichier `words.js` pour insérer votre propre liste de mots (plusieu
 - **Historique** : affiche la liste des parties précédentes et permet de vider cette liste.
 - **Exporter / Importer l'historique** : permet de sauvegarder ou charger les parties enregistrées au format JSON.
 - **Stats** : affiche pour chaque joueur son score total, le nombre de parties jouées et sa date d'inscription.
+- **Règles** : rappelle les principes du jeu à tout moment.
 
 ## Historique des parties
 L'application mémorise localement chaque partie terminée. Le bouton **Historique** ouvre une fenêtre récapitulative indiquant la date et le score de chaque équipe. Depuis cette fenêtre, vous pouvez également effacer toutes les données enregistrées.
@@ -48,3 +49,4 @@ Les fenêtres d'historique et de statistiques adoptent désormais un style diff�
 
 ## Design amélioré
 La feuille de style a été retravaillée afin d'offrir une interface plus claire et plus agréable. Les équipes sont mieux mises en valeur sur le tableau de score et le bouton permettant de changer de thème dispose d'une étiquette d'accessibilité.
+Un bouton **Règles** a aussi été ajouté pour rappeler rapidement le principe du jeu.

--- a/index.html
+++ b/index.html
@@ -28,6 +28,7 @@
         <button id="start-game" disabled>Commencer la partie</button>
         <button id="show-history-config">Historique</button>
         <button id="show-stats-config">Stats</button>
+        <button id="show-rules-config">Règles</button>
     </div>
 
     <div id="game-container" class="container">
@@ -55,6 +56,7 @@
             <button id="menu-btn">Menu</button>
             <button id="show-history-game">Historique</button>
             <button id="show-stats-game">Stats</button>
+            <button id="show-rules-game">Règles</button>
         </div>
     </div>
         <div id="history-modal" class="modal" style="display:none">
@@ -76,6 +78,19 @@
                 <ul id="stats-list"></ul>
                 <button id="clear-stats">Réinitialiser les stats</button>
                 <button id="close-stats">Fermer</button>
+            </div>
+        </div>
+        <div id="rules-modal" class="modal" style="display:none">
+            <div class="modal-content menu" id="rules-content">
+                <h2>Règles du jeu</h2>
+                <ol id="rules-list">
+                    <li>Depuis l'écran de configuration, créez les équipes et leurs joueurs puis démarrez la partie.</li>
+                    <li>Appuyez sur <strong>Nouvelle manche</strong> pour obtenir un mot et lancer le chrono.</li>
+                    <li>L'équipe active fait deviner le mot sans le prononcer.</li>
+                    <li>Lorsque le mot est trouvé, sélectionnez le joueur gagnant puis cliquez sur <strong>Mot trouvé</strong>.</li>
+                    <li>L'équipe suivante devient active et la manche reprend.</li>
+                </ol>
+                <button id="close-rules">Fermer</button>
             </div>
         </div>
     <script src="words.js"></script>

--- a/script.js
+++ b/script.js
@@ -453,6 +453,25 @@ document.getElementById('clear-stats').addEventListener('click', () => {
     renderStats();
 });
 
+function showRules(context) {
+    const modal = document.getElementById('rules-modal');
+    const content = document.getElementById('rules-content');
+    modal.style.display = 'flex';
+    content.classList.toggle('game', context === 'game');
+    content.classList.toggle('menu', context !== 'game');
+}
+
+function closeRules() {
+    document.getElementById('rules-modal').style.display = 'none';
+}
+
+const rulesConfigBtn = document.getElementById('show-rules-config');
+if (rulesConfigBtn) rulesConfigBtn.addEventListener('click', () => showRules('menu'));
+const rulesGameBtn = document.getElementById('show-rules-game');
+if (rulesGameBtn) rulesGameBtn.addEventListener('click', () => showRules('game'));
+
+document.getElementById('close-rules').addEventListener('click', closeRules);
+
 document.getElementById('theme-toggle').addEventListener('click', () => {
     currentTheme = currentTheme === 'dark' ? 'light' : 'dark';
     applyTheme();

--- a/style.css
+++ b/style.css
@@ -372,3 +372,10 @@ select {
     background: rgba(0, 0, 0, 0.05);
     border-radius: 6px;
 }
+#rules-list {
+    text-align: left;
+    margin-bottom: 10px;
+}
+#rules-list li {
+    margin-bottom: 4px;
+}


### PR DESCRIPTION
## Summary
- add Rules button in configuration and game views
- display the rules in a new modal dialog
- wire up JS to open/close the rules modal
- style rules list and document the feature

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6842e22922cc8322b8e6662963adaec5