### PR TITLE
Amélioration légère du design

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,3 +55,4 @@ Les fenêtres d'historique et de statistiques adoptent désormais un style diff�
 ## Design amélioré
 La feuille de style a été retravaillée afin d'offrir une interface plus claire et plus agréable. Les équipes sont mieux mises en valeur sur le tableau de score et le bouton permettant de changer de thème dispose d'une étiquette d'accessibilité.
 Un bouton **Règles** a aussi été ajouté pour rappeler rapidement le principe du jeu.
+Les cartes des équipes et l'affichage du mot bénéficient désormais d'un effet « verre dépoli » pour un rendu plus moderne.

--- a/style.css
+++ b/style.css
@@ -149,13 +149,13 @@ h1 {
 }
 #scoreboard {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
-    background: rgba(255, 255, 255, 0.7);
-    padding: 10px;
-    border-radius: 16px;
+    grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+    background: rgba(255, 255, 255, 0.8);
+    padding: 20px;
+    border-radius: 20px;
     margin-bottom: 20px;
-    gap: 10px;
-    backdrop-filter: blur(4px);
+    gap: 15px;
+    backdrop-filter: blur(6px);
     animation: fadeIn 0.5s ease;
 }
 
@@ -165,9 +165,10 @@ h1 {
     animation: fadeIn 0.4s ease;
     color: var(--text-light);
     padding: 20px 15px;
-    border-radius: 12px;
-    box-shadow: 0 3px 8px rgba(0, 0, 0, 0.1);
-    border: 1px solid rgba(255, 255, 255, 0.2);
+    border-radius: 16px;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+    border: 1px solid rgba(255, 255, 255, 0.3);
+    backdrop-filter: blur(4px);
     transition: transform 0.3s ease, box-shadow 0.3s ease, background 0.3s ease;
 }
 
@@ -229,8 +230,12 @@ h1 {
     font-size: 2em;
     margin: 20px 0;
     color: var(--primary);
-    text-shadow: 0 2px 4px rgba(0,0,0,0.15);
+    text-shadow: 0 2px 4px rgba(0, 0, 0, 0.15);
     font-weight: bold;
+    padding: 5px 10px;
+    border-radius: 8px;
+    background: rgba(255, 255, 255, 0.6);
+    backdrop-filter: blur(4px);
 }
 
 #word-display.hidden {


### PR DESCRIPTION
## Notes
- Pas de tests automatisés dans le dépôt (`npm test` échoue faute de `package.json`).

## Résumé
- meilleur affichage du tableau des scores (cartes plus grandes avec effet flou)
- effet de verre dépoli sur le mot affiché
- documentation mise à jour sur ces améliorations

------
https://chatgpt.com/codex/tasks/task_e_684435941c2483229fe7aaf0060d09e1