### PR TITLE
Improve smartphone UX and accessibility

### DIFF
--- a/index.html
+++ b/index.html
@@ -73,7 +73,7 @@
             </div>
         </div>
     </div>
-        <div id="history-modal" class="modal" style="display:none">
+        <div id="history-modal" class="modal">
             <div class="modal-content menu" id="history-content">
                 <h2 id="history-title">Historique des parties</h2>
                 <ul id="history-list"></ul>
@@ -86,7 +86,7 @@
                 <button id="close-history">Fermer</button>
             </div>
         </div>
-        <div id="stats-modal" class="modal" style="display:none">
+        <div id="stats-modal" class="modal">
             <div class="modal-content menu" id="stats-content">
                 <h2 id="stats-title">Classement des joueurs</h2>
                 <ul id="stats-list"></ul>
@@ -94,7 +94,7 @@
                 <button id="close-stats">Fermer</button>
             </div>
         </div>
-        <div id="rules-modal" class="modal" style="display:none">
+        <div id="rules-modal" class="modal">
             <div class="modal-content menu" id="rules-content">
                 <h2>Règles du jeu</h2>
                 <ol id="rules-list">

--- a/script.js
+++ b/script.js
@@ -33,11 +33,14 @@ function createPlayer(name) {
 
 function applyTheme() {
     const dark = currentTheme === 'dark';
+    const contrast = currentTheme === 'contrast';
     document.body.classList.toggle('dark', dark);
     document.documentElement.classList.toggle('dark', dark);
+    document.body.classList.toggle('contrast', contrast);
+    document.documentElement.classList.toggle('contrast', contrast);
     const btn = document.getElementById('theme-toggle');
     if (btn) {
-        btn.textContent = dark ? '☀️' : '🌙';
+        btn.textContent = currentTheme === 'light' ? '🌙' : currentTheme === 'dark' ? '🔳' : '☀️';
     }
 }
 
@@ -442,7 +445,7 @@ function showHistory(context) {
     const modal = document.getElementById('history-modal');
     const content = document.getElementById('history-content');
     const title = document.getElementById('history-title');
-    modal.style.display = 'flex';
+    modal.classList.add('open');
     content.classList.toggle('game', context === 'game');
     content.classList.toggle('menu', context !== 'game');
     if (title) {
@@ -451,7 +454,7 @@ function showHistory(context) {
 }
 
 function closeHistory() {
-    document.getElementById('history-modal').style.display = 'none';
+    document.getElementById('history-modal').classList.remove('open');
 }
 
 const historyConfigBtn = document.getElementById('show-history-config');
@@ -530,7 +533,7 @@ function showStats(context) {
     const modal = document.getElementById('stats-modal');
     const content = document.getElementById('stats-content');
     const title = document.getElementById('stats-title');
-    modal.style.display = 'flex';
+    modal.classList.add('open');
     content.classList.toggle('game', context === 'game');
     content.classList.toggle('menu', context !== 'game');
     if (title) {
@@ -539,7 +542,7 @@ function showStats(context) {
 }
 
 function closeStats() {
-    document.getElementById('stats-modal').style.display = 'none';
+    document.getElementById('stats-modal').classList.remove('open');
 }
 
 const statsConfigBtn = document.getElementById('show-stats-config');
@@ -558,13 +561,13 @@ document.getElementById('clear-stats').addEventListener('click', () => {
 function showRules(context) {
     const modal = document.getElementById('rules-modal');
     const content = document.getElementById('rules-content');
-    modal.style.display = 'flex';
+    modal.classList.add('open');
     content.classList.toggle('game', context === 'game');
     content.classList.toggle('menu', context !== 'game');
 }
 
 function closeRules() {
-    document.getElementById('rules-modal').style.display = 'none';
+    document.getElementById('rules-modal').classList.remove('open');
 }
 
 const rulesConfigBtn = document.getElementById('show-rules-config');
@@ -576,14 +579,14 @@ document.getElementById('close-rules').addEventListener('click', closeRules);
 
 document.addEventListener('keydown', e => {
     if (e.key === 'Escape') {
-        if (document.getElementById('history-modal').style.display === 'flex') closeHistory();
-        if (document.getElementById('stats-modal').style.display === 'flex') closeStats();
-        if (document.getElementById('rules-modal').style.display === 'flex') closeRules();
+        if (document.getElementById('history-modal').classList.contains('open')) closeHistory();
+        if (document.getElementById('stats-modal').classList.contains('open')) closeStats();
+        if (document.getElementById('rules-modal').classList.contains('open')) closeRules();
     }
 });
 
 document.getElementById('theme-toggle').addEventListener('click', () => {
-    currentTheme = currentTheme === 'dark' ? 'light' : 'dark';
+    currentTheme = currentTheme === 'light' ? 'dark' : currentTheme === 'dark' ? 'contrast' : 'light';
     applyTheme();
     persist();
 });

--- a/style.css
+++ b/style.css
@@ -55,6 +55,32 @@
     --team8: #c084fc;
 }
 
+:root.contrast {
+    --primary: #000000;
+    --secondary: #ffffff;
+    --accent: #ffff00;
+    --success: #00ff00;
+    --bg-start: #000000;
+    --bg-end: #000000;
+    --accent-light: #ffff00;
+    --container-bg1: rgba(0, 0, 0, 0.95);
+    --container-bg2: rgba(0, 0, 0, 0.8);
+    --team-end: #000000;
+    --team-hover-end: #222222;
+    --button-secondary: #000000;
+    --timer-bg: #000000;
+    --input-border: #ffffff;
+    --text-light: #ffffff;
+    --team1: #ffff00;
+    --team2: #ff00ff;
+    --team3: #00ffff;
+    --team4: #ff0000;
+    --team5: #00ff00;
+    --team6: #ff8800;
+    --team7: #00aaff;
+    --team8: #ff00aa;
+}
+
 body {
     font-family: "Poppins", "Montserrat", "Segoe UI", Tahoma, Geneva, Verdana, sans-serif;
     font-size: var(--font-base);
@@ -71,6 +97,10 @@ body {
 
 h1, h2, h3 {
     font-family: "Fredoka", "Poppins", "Montserrat", sans-serif;
+}
+
+html {
+    scroll-behavior: smooth;
 }
 
 #theme-toggle {
@@ -163,6 +193,8 @@ h1 {
     gap: 20px;
     backdrop-filter: blur(6px);
     animation: fadeIn 0.5s ease;
+    max-height: 60vh;
+    overflow-y: auto;
 }
 
 .team {
@@ -432,6 +464,23 @@ select {
     }
 }
 
+/* Tablettes et petits ordinateurs */
+@media (max-width: 768px) {
+    .container {
+        padding: 20px;
+    }
+    #scoreboard {
+        grid-template-columns: repeat(2, 1fr);
+    }
+    #word-display {
+        font-size: 2em;
+    }
+    button {
+        font-size: 1em;
+        padding: 10px 18px;
+    }
+}
+
 .modal {
     position: fixed;
     top: 0;
@@ -443,6 +492,16 @@ select {
     align-items: center;
     justify-content: center;
     z-index: 2000;
+    opacity: 0;
+    visibility: hidden;
+    pointer-events: none;
+    transition: opacity 0.3s ease;
+}
+
+.modal.open {
+    opacity: 1;
+    visibility: visible;
+    pointer-events: auto;
 }
 
 .modal-content {
@@ -452,6 +511,11 @@ select {
     max-width: 400px;
     width: 90%;
     color: var(--secondary);
+    transform: scale(0.95);
+    transition: transform 0.3s ease;
+}
+.modal.open .modal-content {
+    transform: scale(1);
 }
 .modal-content.menu {
     border-top: 4px solid var(--primary);


### PR DESCRIPTION
## Summary
- add a high-contrast CSS theme
- smooth modal opening with fade animation
- allow cycling through light/dark/contrast themes
- hide modals using CSS classes
- adjust layout for small devices and tablets

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6845e1e139e883229a0b9e816d171d00