### PR TITLE
Improve mobile layout

### DIFF
--- a/style.css
+++ b/style.css
@@ -29,6 +29,11 @@
     display: none !important;
 }
 
+/* Ensure padding does not create horizontal overflow */
+*, *::before, *::after {
+    box-sizing: border-box;
+}
+
 :root.dark {
     --primary: #8b5cf6;
     --secondary: #f3f4f6;
@@ -160,6 +165,7 @@ body.dark #theme-toggle {
     align-items: center;
     justify-content: center;
     gap: 10px;
+    flex-wrap: wrap;
 }
 #round-duration {
     width: 70px;
@@ -457,6 +463,16 @@ select {
         margin: 3px 0;
         width: 100%;
         min-height: 40px;
+    }
+
+    #setup {
+        justify-content: flex-start;
+    }
+    #setup label,
+    #setup select,
+    #setup input,
+    #setup button {
+        width: 100%;
     }
 
     #toggle-word {


### PR DESCRIPTION
## Summary
- prevent horizontal overflow by setting global box-sizing
- allow wrapping of the configuration form
- tweak mobile styles for configuration section

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6845e688507c8322ad925d41fd848186